### PR TITLE
Add few process related functions from psapi.dll

### DIFF
--- a/src/win32.lisp
+++ b/src/win32.lisp
@@ -6221,6 +6221,11 @@ Meant to be used around win32 C preprocessor macros which have to be implemented
   (proc :pointer)
   (lparam lparam))
 
+(defwin32fun ("EnumProcesses" enum-processes psapi) bool
+  (lpid-process (:pointer dword))
+  (cb dword)
+  (cb-needed (:pointer dwordlong)))
+
 (defwin32fun ("EnumWindows" enum-windows user32) bool
   (callback :pointer)
   (lparam lparam))
@@ -6629,6 +6634,11 @@ Meant to be used around win32 C preprocessor macros which have to be implemented
 (defwin32fun ("GetProcAddress" get-proc-address kernel32) far-proc
   (module hmodule)
   (proc-name lpcstr))
+
+(defwin32fun ("GetProcessImageFileNameW" get-process-image-file-name psapi) dword
+  (hprocess handle)
+  (lpimage-file-name lpwstr)
+  (nsize dword))
 
 (defwin32-lispfun get-proc-address* (module ordinal)
   (declare (type (unsigned-byte 16) ordinal))
@@ -8183,18 +8193,3 @@ Meant to be used around win32 C preprocessor macros which have to be implemented
 (defwin32-lispfun zero-memory (destination length)
   (dotimes (i length)
     (setf (cffi:mem-aref destination :uint8 i) 0)))
-
-(defwin32fun ("EnumProcesses" enum-processes psapi) bool
-  (lpid-process (:pointer dword))
-  (cb dword)
-  (cb-needed (:pointer dwordlong)))
-
-(defwin32fun ("GetProcessImageFileNameA" get-process-image-file-name-a psapi) dword
-  (hprocess handle)
-  (lpimage-file-name lpstr)
-  (n-size dword))
-
-(defwin32fun ("GetProcessImageFileNameW" get-process-image-file-name-w psapi) dword
-  (hprocess handle)
-  (lpimage-file-name lpwstr)
-  (n-size dword))

--- a/src/win32.lisp
+++ b/src/win32.lisp
@@ -8183,3 +8183,18 @@ Meant to be used around win32 C preprocessor macros which have to be implemented
 (defwin32-lispfun zero-memory (destination length)
   (dotimes (i length)
     (setf (cffi:mem-aref destination :uint8 i) 0)))
+
+(defwin32fun ("EnumProcesses" enum-processes psapi) bool
+  (lpid-process (:pointer dword))
+  (cb dword)
+  (cb-needed (:pointer dwordlong)))
+
+(defwin32fun ("GetProcessImageFileNameA" get-process-image-file-name-a psapi) dword
+  (hprocess handle)
+  (lpimage-file-name lpstr)
+  (n-size dword))
+
+(defwin32fun ("GetProcessImageFileNameW" get-process-image-file-name-w psapi) dword
+  (hprocess handle)
+  (lpimage-file-name lpwstr)
+  (n-size dword))


### PR DESCRIPTION
Example usage below. I am learning common-lisp once again here. Do things step by step and I don't feel like this code below is ready for public.

```lisp
(defun win32-psapi-enum-processes (&optional (size 2048))
  "Return list of process identifiers and it's size.

Examples: 
* (win32-psapi-enum-processes) => (0 4 72 128 464 732 480 656 816 828
612 948 1128 1176 1340 1384 1476 1488 1576 1636 ... 8844 7208), 257

https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-enumprocesses"
  (let ((sizeof-dword (cffi:foreign-type-size 'win32:dword)))
    (cffi:with-foreign-objects ((lpid-process 'win32:dword size)
				(cb-needed 'win32:dwordlong))
      (setf (cffi:mem-ref cb-needed 'win32:dwordlong) 0)
      (unless (win32:enum-processes lpid-process (* size sizeof-dword) cb-needed) (error "Failed"))
      (let ((num-of-ids-returned (/ (cffi:mem-ref cb-needed 'win32:dwordlong) sizeof-dword)))
	(values 
	 (loop for i below num-of-ids-returned
	       collect (cffi:mem-aref lpid-process 'win32:dword i))
	 num-of-ids-returned)))))

(defun win32-psapi-enum-process-modules (hprocess &optional (size 2048))
  (let* ((sizeof-dword (cffi:foreign-type-size 'win32:dword))
	 (size-bytes (* size sizeof-dword)))
    (cffi:with-foreign-objects ((lphmodule 'win32:hmodule size)
				(lpcb-needed 'win32:dwordlong))
      (setf (cffi:mem-ref lpcb-needed 'win32:dwordlong) 0)
      (unless (win32:enum-process-modules hprocess lphmodule size-bytes lpcb-needed) (error "Failed"))
      (let ((num-of-handles-returned (/ (cffi:mem-ref lpcb-needed 'win32:dwordlong) sizeof-dword)))
	(values
	 (loop for i below num-of-handles-returned
	       collect (cffi:mem-aref lphmodule 'win32:hmodule i))
	 num-of-handles-returned)))))

(defun win32-kernel32-open-process (dwprocess-id dw-desired-access &optional (inherit-handle nil))
  (win32:open-process dw-desired-access inherit-handle dwprocess-id))


(defun win32-kernel32-close-handle (handle)
  "
https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle"
  (unless (win32:close-handle handle) (error "Failed")))

(defmacro with-open-process (hprocess process-id desired-access &body body)
  (let ((err (gensym)))
    `(let ((,hprocess (win32-kernel32-open-process ,process-id ,desired-access))
	   (,err (win32:get-last-error)))
       (unless ,hprocess (error "Failed with win32 error code ~A" ,err))
       (unwind-protect
	    ,@body
	 (win32-kernel32-close-handle ,hprocess)))))

(defun win32-psapi-get-process-image-file-name-w (hprocess &optional (nsize 1024))
  (cffi:with-foreign-object (lpimage-file-name 'win32:wchar nsize)
    (let ((ret (win32:get-process-image-file-name-w hprocess lpimage-file-name nsize))
	  (err (win32:get-last-error)))
      (if (zerop ret)
	  (error "Failed. Error code: ~A" err)
	  (cffi:foreign-string-to-lisp lpimage-file-name :encoding win32:+win32-string-encoding+)))))

(defun list-processes ()
  (labels ((image-file-name (process-id)
	     (handler-case 
		 (with-open-process handle process-id win32:+process-query-limited-information+
		   (win32-psapi-get-process-image-file-name-w handle))
	       (simple-error (c)
		 (declare (ignore c))
		 ""))))
    (mapcar (lambda (process-id)
	      (list
	       process-id
	       (image-file-name process-id)))
	    (win32-psapi-enum-processes))))
```