### PR TITLE
Misc

### DIFF
--- a/src/win32.lisp
+++ b/src/win32.lisp
@@ -6663,6 +6663,12 @@ Meant to be used around win32 C preprocessor macros which have to be implemented
   (buffer lptstr)
   (size dword))
 
+(defwin32fun ("GetModuleFileNameExW" get-module-file-name-ex kernel32) dword
+  (process handle)
+  (module hmodule)
+  (buffer lptstr)
+  (size dword))
+
 (defwin32fun ("GetModuleHandleW" get-module-handle kernel32) hmodule
   (module lpcwstr))
 

--- a/src/win32.lisp
+++ b/src/win32.lisp
@@ -321,6 +321,13 @@ Meant to be used around win32 C preprocessor macros which have to be implemented
   (cl-size ulong)
   (p-data (:pointer hyper)))
 
+(defwin32struct kbd-ll-hook
+  (vk-code dword)
+  (scan-code dword)
+  (flags dword)
+  (time dword)
+  (extra-info ulong-ptr))
+
 (defwin32type olechar wchar)
 (defwin32type wire-bstr (:pointer flagged-word-blob))
 (defwin32type bstr (:pointer olechar))


### PR DESCRIPTION
Add structure [KBDLLHOOKSTRUCT ](https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-kbdllhookstruct?redirectedfrom=MSDN) for use with `LowLevelKeyboardProc`.

Add function `GetModuleFileNameExW`: 
> Retrieves the fully qualified path for the file that contains the specified module. The module must have been loaded by the current process.